### PR TITLE
make plain-java test pass

### DIFF
--- a/plain-java/pom.xml
+++ b/plain-java/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/plain-java/src/main/java-hotswap/org/hotswap/agent/example/HelloWorldHotswap.java
+++ b/plain-java/src/main/java-hotswap/org/hotswap/agent/example/HelloWorldHotswap.java
@@ -8,7 +8,7 @@ import java.lang.Cloneable;
 @HelloAnnotation("hello hotswap")
 public class HelloWorldHotswap {
     public static String hello() {
-        return "Hello World Hotswap";
+        return helloPrivate();
     }
 
     @HelloAnnotation("hello hotswap")
@@ -26,6 +26,10 @@ public class HelloWorldHotswap {
     // chage ordering of annonymous classes. HotswapperPlugin should kick in.
     public void dummy() {
         new Cloneable() {};
+    }
+
+    private static String helloPrivate() {
+        return "Hello World Hotswap";
     }
 
 }

--- a/plain-java/src/test/java/org/hotswap/agent/example/HelloWorldHotswapTest.java
+++ b/plain-java/src/test/java/org/hotswap/agent/example/HelloWorldHotswapTest.java
@@ -33,7 +33,7 @@ public class HelloWorldHotswapTest {
         copyClassFile(HelloWorldHotswap.class.getName(), false);
         copyClassFile(HelloWorldHotswap.class.getName() + "$1", false); // anonymous Cloneable class in dummy() method
         copyClassFile(HelloWorldHotswap.class.getName() + "$2", false); // anonymous HelloInterface class in hello(String) method
-//        Thread.sleep();
+        Thread.sleep(2000);
 
         // wait for the hotswap
         WaitHelper.waitForCommand(new WaitHelper.Command() {

--- a/plain-java/src/test/java/org/hotswap/agent/example/HelloWorldTest.java
+++ b/plain-java/src/test/java/org/hotswap/agent/example/HelloWorldTest.java
@@ -56,6 +56,7 @@ public class HelloWorldTest {
         Path source = Paths.get("target/watch/testWatchReplace.properties");
         Path target = Paths.get("target/watch/testWatch.properties");
         Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+        Thread.sleep(2000);
 
         // wait for the hotswap
         boolean result = WaitHelper.waitForCommand(new WaitHelper.Command() {

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,43 @@
                         <target>1.8</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.15</version>
+                    <configuration>
+                        <argLine>${hotswap.argline}</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>(,1.9)</jdk>
+            </activation>
+            <properties>
+                <hotswap.argline>-XXaltjvm=dcevm -javaagent:${hotswapagent.jar}</hotswap.argline>
+            </properties>
+        </profile>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <hotswap.argline>-XX:+AllowEnhancedClassRedefinition -XX:HotswapAgent=external
+                    -javaagent:${hotswapagent.jar}
+                </hotswap.argline>
+            </properties>
+        </profile>
+    </profiles>
+
+    <properties>
+        <hotswapagent.jar>specify hotswap agent location</hotswapagent.jar>
+    </properties>
 
 </project>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,19 +9,28 @@ function test {
     echo "Running with Java $1"
     export JAVA_HOME=$1
 
-    echo "Resolved version: " `"$JAVA_HOME/bin/java" -XXaltjvm=dcevm -version` || echo "$1 is not a valid Java installation with DCEVM."
+    echo "Resolved version: " `"$JAVA_HOME/bin/java" -version`
 
-    mvn clean install
+    mvn -Dhotswapagent.jar=$2 clean package
 
-    # run tests for different versions
+    # run tests
     cd plain-java; ./run-tests.sh; cd ..
-    cd plain-servlet; ./run-tests.sh; cd ..
 
     # TODO
     # custom-plugin
+    # cd plain-servlet; ./run-tests.sh; cd ..
     # spring-hibernate
     # ...
 }
 
-test "c:\Program Files\Java\jdk1.7.0_45"
-test "c:\Program Files\Java\jdk1.8.0_05"
+if [ -z "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set"
+    exit 1
+fi
+
+if [ -z "$HOT_SWAP_AGENT"]; then
+  echo "HOT_SWAP_AGENT is not set, pls. specify where the HotSwapAgent jar location"
+  exit 1
+fi
+
+test $JAVA_HOME $HOT_SWAP_AGENT


### PR DESCRIPTION
 This is a companion change for [HotswapProjects/HotswapAgent/pull#469](https://github.com/HotswapProjects/HotswapAgent/pull/469), to make plain-java test pass with Java8, 11 and 17.
