### PR TITLE
make test pass on tomcat6, 7, 8, 9

### DIFF
--- a/hotswap-agent-examples-servlet-parent/pom.xml
+++ b/hotswap-agent-examples-servlet-parent/pom.xml
@@ -210,11 +210,34 @@
     </profiles>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*IT</include>
+                        </includes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
-                <version>1.4.8</version>
+                <artifactId>cargo-maven3-plugin</artifactId>
+                <version>1.10.6</version>
                 <configuration>
                     <skip>${cargo.skip}</skip>
                     <container>
@@ -235,7 +258,7 @@
                     </deployables>
                     <configuration>
                         <properties>
-                            <cargo.jvmargs>-XXaltjvm=${dcevm} -javaagent:${org.hotswap.agent:hotswap-agent:jar}=autoHotswap=true</cargo.jvmargs>
+                            <cargo.jvmargs>${hotswap.argline}=autoHotswap=true</cargo.jvmargs>
                             <cargo.servlet.port>${server.port}</cargo.servlet.port>
                         </properties>
                     </configuration>

--- a/plain-servlet/pom.xml
+++ b/plain-servlet/pom.xml
@@ -139,6 +139,7 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
@@ -155,6 +156,24 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>tomcat9</id>
+
+            <properties>
+                <cargo.skip>false</cargo.skip>
+                <cargo.container>tomcat9x</cargo.container>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
@@ -171,6 +190,7 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
@@ -398,5 +418,5 @@
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
-    
+
 </project>

--- a/plain-servlet/pom.xml
+++ b/plain-servlet/pom.xml
@@ -33,48 +33,7 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>jetty4</id>
-            <properties>
-                <cargo.skip>false</cargo.skip>
-                <cargo.container>jetty4x</cargo.container>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jetty5</id>
-            <properties>
-                <cargo.skip>false</cargo.skip>
-                <cargo.container>jetty5x</cargo.container>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jetty6</id>
-            <properties>
-                <cargo.skip>false</cargo.skip>
-                <cargo.container>jetty6x</cargo.container>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+
         <profile>
             <id>jetty7</id>
             <properties>
@@ -84,11 +43,13 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>jetty8</id>
             <properties>
@@ -98,11 +59,13 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>jetty9</id>
             <properties>
@@ -112,30 +75,19 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>jetty9-run</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+
         <profile>
             <id>tomcat6</id>
-
             <properties>
                 <cargo.skip>false</cargo.skip>
                 <cargo.container>tomcat6x</cargo.container>
             </properties>
-
             <build>
                 <plugins>
                     <plugin>
@@ -145,14 +97,13 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>tomcat7</id>
-
             <properties>
                 <cargo.skip>false</cargo.skip>
                 <cargo.container>tomcat7x</cargo.container>
             </properties>
-
             <build>
                 <plugins>
                     <plugin>
@@ -162,31 +113,13 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>tomcat9</id>
 
-            <properties>
-                <cargo.skip>false</cargo.skip>
-                <cargo.container>tomcat9x</cargo.container>
-            </properties>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>tomcat8</id>
-
             <properties>
                 <cargo.skip>false</cargo.skip>
                 <cargo.container>tomcat8x</cargo.container>
             </properties>
-
             <build>
                 <plugins>
                     <plugin>
@@ -196,6 +129,23 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>tomcat9</id>
+            <properties>
+                <cargo.skip>false</cargo.skip>
+                <cargo.container>tomcat9x</cargo.container>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>jboss5x</id>
 
@@ -272,6 +222,7 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.7</version>
                 <executions>

--- a/plain-servlet/run-tests.sh
+++ b/plain-servlet/run-tests.sh
@@ -18,9 +18,6 @@ fi
 
 # Older versions of Jetty works as well, but are configured only with embedded configuration, which does not support jvmargs
 #  it cannot be launched automatically (set -javaagent). To launch the test, set MAVEN_OPTS and run manually.
-# test jetty4
-# test jetty5
-test jetty6 ${HOT_SWAP_AGENT}
 test jetty7 ${HOT_SWAP_AGENT}
 test jetty8 ${HOT_SWAP_AGENT}
 test jetty9 ${HOT_SWAP_AGENT}

--- a/plain-servlet/run-tests.sh
+++ b/plain-servlet/run-tests.sh
@@ -8,22 +8,28 @@ set -e
 # run clean install (with all integration tests)
 function test {
     echo "Running with container $1"
-    mvn clean install -P $1
+    mvn -Dhotswapagent.jar=$2 clean verify -P $1
 }
+
+if [ -z "$HOT_SWAP_AGENT"]; then
+  echo "HOT_SWAP_AGENT is not set, pls. specify where the HotSwapAgent jar location"
+  exit 1
+fi
 
 # Older versions of Jetty works as well, but are configured only with embedded configuration, which does not support jvmargs
 #  it cannot be launched automatically (set -javaagent). To launch the test, set MAVEN_OPTS and run manually.
 # test jetty4
 # test jetty5
-test jetty6
-test jetty7
-test jetty8
-test jetty9
+test jetty6 ${HOT_SWAP_AGENT}
+test jetty7 ${HOT_SWAP_AGENT}
+test jetty8 ${HOT_SWAP_AGENT}
+test jetty9 ${HOT_SWAP_AGENT}
 
 # Tomcat should be Ok.
-test tomcat6
-test tomcat7
-test tomcat8
+test tomcat6 ${HOT_SWAP_AGENT}
+test tomcat7 ${HOT_SWAP_AGENT}
+test tomcat8 ${HOT_SWAP_AGENT}
+test tomcat9 ${HOT_SWAP_AGENT}
 
 # Almost all hotswap agent properties do not work :-(
 #test jboss5x

--- a/plain-servlet/src/test/java/org/hotswap/agent/example/HelloWorldServletHotswapIT.java
+++ b/plain-servlet/src/test/java/org/hotswap/agent/example/HelloWorldServletHotswapIT.java
@@ -42,7 +42,7 @@ public class HelloWorldServletHotswapIT {
 
                 return "Hello World Hotswap".equals(result);
             }
-        });
+        }, 2000);
 
         // check that agentexamples works
         Assert.assertTrue("Assert hotswapped class in extra is used.", result);

--- a/plain-servlet/src/test/java/org/hotswap/agent/example/HelloWorldServletIT.java
+++ b/plain-servlet/src/test/java/org/hotswap/agent/example/HelloWorldServletIT.java
@@ -69,7 +69,7 @@ public class HelloWorldServletIT {
                 System.err.println(hello);
                 return "Hello World Watch".equals(hello);
             }
-        });
+        }, 4000);
 
         // check that agentexamples works
         Assert.assertTrue("Assert modified target/watch/testWatch.properties is used.", result);


### PR DESCRIPTION
Enhance plain-servlet, and verify the integration test can pass tomcat6, 7, 8, 9. This is a companion change of HotswapProjects/HotswapAgent#470 and HotswapProjects/HotswapAgent#471

Also verify jetty7, jetty8, jetty9 work too, but right now HotswapAgent stops working with jetty 10 and later.